### PR TITLE
Example of using config files in settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+src/dhm_module_base/configs/config.ini
+
 #visual studio code
 .vscode
 

--- a/src/dhm_module_base/cli.py
+++ b/src/dhm_module_base/cli.py
@@ -27,6 +27,7 @@ def configure_logging(log_level):
 @click.version_option(version=__version__)
 @options.verbosity_arg
 @options.configuration_arg
+@click.pass_context
 def cli(ctx, verbosity, config):
     """dhm_module_base command line interface."""
     ctx.ensure_object(dict)
@@ -41,8 +42,7 @@ def cli(ctx, verbosity, config):
     # by passing the click decorator @click.pass_context
     ctx.obj["config"] = config
 
-    if not verbosity:
-        configure_logging(config["DEFAULT"]["loglevel"])
-
     if verbosity:
         configure_logging(verbosity)
+    else:
+        configure_logging(config.get("loglevel"))

--- a/src/dhm_module_base/cli.py
+++ b/src/dhm_module_base/cli.py
@@ -8,6 +8,7 @@ from dhm_module_base.helpers import (
     ClickColoredLoggingFormatter,
     ClickLoggingHandler,
 )
+from dhm_module_base.settings import Configuration
 
 
 def configure_logging(log_level):
@@ -25,6 +26,23 @@ def configure_logging(log_level):
 @click.group("dhm_module_base")
 @click.version_option(version=__version__)
 @options.verbosity_arg
-def cli(verbosity):
+@options.configuration_arg
+def cli(ctx, verbosity, config):
     """dhm_module_base command line interface."""
-    configure_logging(verbosity)
+    ctx.ensure_object(dict)
+
+    if config:
+        config = Configuration(path=config.name).config
+    else:
+        config = Configuration().config
+
+    # Pass the configuration object to the current CLI context
+    # This allows plugin or subcommands to retrieve it from the context
+    # by passing the click decorator @click.pass_context
+    ctx.obj["config"] = config
+
+    if not verbosity:
+        configure_logging(config["DEFAULT"]["loglevel"])
+
+    if verbosity:
+        configure_logging(verbosity)

--- a/src/dhm_module_base/configs/dummy.ini
+++ b/src/dhm_module_base/configs/dummy.ini
@@ -1,0 +1,23 @@
+# This is a dummy configuration
+# Configurations should not be exposed publicly if they contain sensitive information
+# config.ini is added to .gitignore but can be supplied from wherever
+[DEFAULT]
+dhm_path = "../../tests/data"
+bool_flag = true
+tile_size = 1024
+loglevel = "ERROR"
+user = "xxx"
+pass = "yyy"
+host = "example.com"
+schema = "testschema"
+table = "testtable"
+
+[dev]
+user = "dev_user"
+pass = "dev_pass"
+log_level = "DEBUG"
+
+[prod]
+log_level = "ERROR"
+user = "prod_user"
+pass = "prod_pass"

--- a/src/dhm_module_base/options.py
+++ b/src/dhm_module_base/options.py
@@ -1,8 +1,4 @@
 import click
-from dhm_module_base.settings import Configuration
-
-CONFIG = Configuration().config
-LOG_LEVEL = CONFIG["DEFAULT"]["loglevel"]
 
 # pylint: disable=invalid-name
 verbosity_levels = ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"]
@@ -11,6 +7,15 @@ verbosity_arg = click.option(
     "-v",
     # pylint: disable=unexpected-keyword-arg
     type=click.Choice(choices=verbosity_levels, case_sensitive=False),
-    default=LOG_LEVEL,
+    default="ERROR",
     help="Set verbosity level",
+)
+
+configuration_arg = click.option(
+    "--config",
+    "-c",
+    # pylint: disable=unexpected-keyword-arg
+    type=click.File("rb"),
+    default=None,
+    help="Configuration file",
 )

--- a/src/dhm_module_base/options.py
+++ b/src/dhm_module_base/options.py
@@ -1,4 +1,8 @@
 import click
+from dhm_module_base.settings import Configuration
+
+CONFIG = Configuration().config
+LOG_LEVEL = CONFIG["DEFAULT"]["loglevel"]
 
 # pylint: disable=invalid-name
 verbosity_levels = ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"]
@@ -7,6 +11,6 @@ verbosity_arg = click.option(
     "-v",
     # pylint: disable=unexpected-keyword-arg
     type=click.Choice(choices=verbosity_levels, case_sensitive=False),
-    default="ERROR",
+    default=LOG_LEVEL,
     help="Set verbosity level",
 )

--- a/src/dhm_module_base/settings.py
+++ b/src/dhm_module_base/settings.py
@@ -5,7 +5,7 @@ import os
 class Configuration:
     """Instantiate a Configuration object."""
 
-    ENVS = ["local", "dev", "prod"]
+    ENVS = ["DEFAULT", "local", "dev", "prod"]
     cwd = os.path.dirname(__file__)
     # If the configuration is local to the module, put it here.
     default_config = os.path.join(cwd, "configs", "config.ini")
@@ -68,16 +68,16 @@ class Configuration:
         else:
             raise FileNotFoundError("File %s not found" % path)
 
-    def get(self, prop):
-        """Get a property from the configuration.
-
-        Returns:
-            str: The property
-        """
-        try:
-            self.config.get(self.env, prop)
-        except configparser.Error:
-            raise KeyError(
-                "Could not find %s using section %s in file %s"
-                % (prop, self.env, self.path)
-            )
+    # def get(self, prop):
+    #    """Get a property from the configuration.
+    #
+    #    Returns:
+    #        str: The property
+    #    """
+    #    try:
+    #        self.config.get(self.env, prop)
+    #    except configparser.Error:
+    #        raise KeyError(
+    #            "Could not find %s using section %s in file %s"
+    #            % (prop, self.env, self.path)
+    #        )

--- a/src/dhm_module_base/settings.py
+++ b/src/dhm_module_base/settings.py
@@ -1,0 +1,69 @@
+import configparser
+import os
+
+
+class Configuration(object):
+    """Instantiate a Configuration object."""
+
+    ENVS = ["local", "dev", "prod"]
+    cwd = os.path.dirname(__file__)
+    # If the configuration is local to the module, put it here.
+    default_config = os.path.join(cwd, "configs", "config.ini")
+    if not os.path.exists(default_config):
+        default_config = os.path.join(cwd, "configs", "dummy.ini")
+
+    def __init__(self, env="dev", path=default_config):
+        """__init__.
+
+        Args:
+            env (str): env to use for connections etc
+            path (str): Path to configuration file, allows to overwrite the default configuration
+        """
+        self.config = configparser.ConfigParser()
+        self.env = env
+        self.path = path
+
+    @property
+    def env(self):
+        """Env section to use for connections."""
+        return self.env
+
+    @env.setter
+    def env(self, env):
+        """Validator for env.
+
+        Args:
+            env (str): Environment to use, accepted values are local | dev | prod
+
+        Raises:
+            ValueError: Raised if env is not in list
+        """
+        if env in self.ENVS:
+            # pylint: disable=attribute-defined-outside-init
+            self._env = env
+        else:
+            raise ValueError(
+                "%s not in accepted values %s" % (str(env), str(self.ENVS))
+            )
+
+    @property
+    def path(self):
+        """Configuration file path."""
+        return self._path
+
+    @path.setter
+    def path(self, path):
+        """Validator for path.
+
+        Args:
+            path (str): Path to configuration file
+
+        Raises:
+            FileNotFoundError: If configuration file is not found
+        """
+        if os.path.exists(path):
+            # pylint: disable=attribute-defined-outside-init
+            self._path = path
+            self.config.read(path)
+        else:
+            raise FileNotFoundError("File %s not found" % path)

--- a/src/dhm_module_base/settings.py
+++ b/src/dhm_module_base/settings.py
@@ -2,7 +2,7 @@ import configparser
 import os
 
 
-class Configuration(object):
+class Configuration:
     """Instantiate a Configuration object."""
 
     ENVS = ["local", "dev", "prod"]
@@ -12,7 +12,7 @@ class Configuration(object):
     if not os.path.exists(default_config):
         default_config = os.path.join(cwd, "configs", "dummy.ini")
 
-    def __init__(self, env="dev", path=default_config):
+    def __init__(self, env="DEFAULT", path=default_config):
         """__init__.
 
         Args:
@@ -20,8 +20,8 @@ class Configuration(object):
             path (str): Path to configuration file, allows to overwrite the default configuration
         """
         self.config = configparser.ConfigParser()
-        self.env = env
         self.path = path
+        self.env = env
 
     @property
     def env(self):
@@ -67,3 +67,17 @@ class Configuration(object):
             self.config.read(path)
         else:
             raise FileNotFoundError("File %s not found" % path)
+
+    def get(self, prop):
+        """Get a property from the configuration.
+
+        Returns:
+            str: The property
+        """
+        try:
+            self.config.get(self.env, prop)
+        except configparser.Error:
+            raise KeyError(
+                "Could not find %s using section %s in file %s"
+                % (prop, self.env, self.path)
+            )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,3 +21,13 @@ def test_cli_version(cli_runner):
     result = cli_runner.invoke(cli, ["--version"], catch_exceptions=False)
     expected = f"dhm_module_base, version {dhm_module_base.__version__}\n"
     assert result.output == expected
+
+
+def test_cli_configuration(cli_runner):
+    """Call the version command with a configuration file."""
+    result = cli_runner.invoke(
+        cli,
+        ["--version", "--config", "../src/dhm_module_base/confis/dummy.ini"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0


### PR DESCRIPTION
Can be extended with more complex files, often used properties can be coded in etc.

Configuration classes uses Pythons "configparser" to read `.ini` files. Default configuration will be provided, as well as an option to provide path for the configuration on the command line. Configuration object is retrieveable by plugin modules, a test will be written for this. 

